### PR TITLE
Use markdown for dataQuality.

### DIFF
--- a/ckanext/stadtzhtheme/templates/package/snippets/additional_info.html
+++ b/ckanext/stadtzhtheme/templates/package/snippets/additional_info.html
@@ -116,7 +116,7 @@
   {% if pkg_dict.dataQuality %}
     <div class="package-dataquality">
     <h5>{{ _("Data quality") }}</h5>
-      {{ pkg_dict.dataQuality|safe }}
+      {{ pkg_dict.dataQuality }}
     </div>
   {% endif %}
 

--- a/ckanext/stadtzhtheme/templates/package/snippets/package_metadata_fields.html
+++ b/ckanext/stadtzhtheme/templates/package/snippets/package_metadata_fields.html
@@ -124,7 +124,7 @@
   {% endif %}
   {{ form.markdown('sszBemerkungen', label=_('Comments'), id='field-sszBemerkungen', placeholder=_('Comments'), value=value, error=errors.sszBemerkungen) }}
   
-  {{ form.textarea('dataQuality', label=_('Data quality'), id='field-dataQuality', placeholder=_('Data quality'), value=data.dataQuality, error=errors.dataQuality, classes=['control-full']) }}
+  {{ form.markdown('dataQuality', label=_('Data quality'), id='field-dataQuality', placeholder=_('Data quality'), value=data.dataQuality, error=errors.dataQuality, classes=['control-full']) }}
 
   {% set fields = [] %}
   {% if data.sszFields %}


### PR DESCRIPTION
Removes any need to not escape contents of dataQuality field on dataset page.
