### PR TITLE
Use internal or external URL for AJAX requests depending on request

### DIFF
--- a/ckanext/stadtzhtheme/plugin.py
+++ b/ckanext/stadtzhtheme/plugin.py
@@ -189,6 +189,20 @@ def is_url(*args, **kw):
     valid_schemes = ('http', 'https', 'ftp')
     return url.scheme in valid_schemes
 
+def get_ajax_api_endpoint():
+    '''
+    Returns the URL endpoint for AJAX calls.
+    Depending on the request, it could be the internal or external site URL
+    '''
+    try:
+        request_url = urlparse.urlparse(request.url)
+        internal_url = urlparse.urlparse(config.get('ckan.site_url_internal', 'https://ogd.global.szh.loc'))
+        if request_url.netloc == internal_url.netloc:
+            return config.get('ckan.site_url_internal')
+    except ValueError:
+        pass
+    return config.get('ckan.site_url')
+
 def full_external_url():
     ''' Returns the fully qualified current external url (eg http://...) useful
     for sharing etc '''
@@ -274,6 +288,7 @@ class StadtzhThemePlugin(plugins.SingletonPlugin,
             'validate_email': validate_email,
             'get_organization_dict': get_organization_dict,
             'full_external_url': full_external_url,
+            'get_ajax_api_endpoint': get_ajax_api_endpoint,
             'is_url': is_url,
             'get_site_protocol': get_site_protocol,
             'get_site_host': get_site_host,

--- a/ckanext/stadtzhtheme/templates/base.html
+++ b/ckanext/stadtzhtheme/templates/base.html
@@ -13,4 +13,4 @@
   {% resource 'stadtzhtheme/stadtzhtheme.css' %}
 {% endblock %}
 
-{% block bodytag %} data-site-root="{{ g.site_url }}/" data-locale-root="{{ g.site_url }}/" {% endblock %}
+{% block bodytag %} data-site-root="{{ h.get_ajax_api_endpoint() }}/" data-locale-root="{{ h.get_ajax_api_endpoint() }}/" {% endblock %}


### PR DESCRIPTION
This makes sure, that API requests target the current URL and no
Cross-Domain requests are required. This is necessary to ensure AJAX
calls, that are not allowed on the external URL to be processed
correctly (i.e. reordering of resources).