### PR TITLE
Make sure ampersands are not stripped when rendering markdown

### DIFF
--- a/ckanext/stadtzhtheme/templates/package/snippets/additional_info.html
+++ b/ckanext/stadtzhtheme/templates/package/snippets/additional_info.html
@@ -134,7 +134,7 @@
   {% if comments %}
     <h3>{{ _("Comments") }}</h3>
     <div class="package-comments">
-      {{ h.render_markdown(comments[0]) }}
+      {{ h.render_markdown(comments[0], allow_html=True) }}
     </div>
   {% endif %}
 


### PR DESCRIPTION
Workaround for https://github.com/ckan/ckan/issues/3356