### PR TITLE
Change travis dist to trusty and fix psycopg2 error in travis build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 sudo: required
-dist: precise
+dist: trusty
+group: deprecated-2017Q4
 
 language: python
 
@@ -7,7 +8,6 @@ python:
 - '2.7'
 
 env:
-    - CKANVERSION=master
     - CKANVERSION=2.7
 
 services:
@@ -18,3 +18,5 @@ install:
     - bash bin/travis-build.bash
 
 script: bin/travis-run.sh
+
+after_success: coveralls

--- a/bin/travis-build.bash
+++ b/bin/travis-build.bash
@@ -18,18 +18,9 @@ else
     git checkout $CKAN_TAG
     echo "CKAN version: ${CKAN_TAG#ckan-}"
 fi
-
-# install the recommended version of setuptools
-if [ -f requirement-setuptools.txt ]
-then
-    echo "Updating setuptools..."
-    pip install -r requirement-setuptools.txt
-fi
-
 python setup.py develop
-
-pip install -r requirements.txt
-pip install -r dev-requirements.txt
+pip install -r requirements.txt --allow-all-external
+pip install -r dev-requirements.txt --allow-all-external
 cd -
 
 echo "Setting up Solr..."


### PR DESCRIPTION
the new trusty images of Travis cause build errors with psycopg2:
see travis-ci/travis-ci#8897