### PR TITLE
Fix generation of resource download link.

### DIFF
--- a/ckanext/stadtzhtheme/plugin.py
+++ b/ckanext/stadtzhtheme/plugin.py
@@ -608,7 +608,7 @@ class StadtzhThemePlugin(plugins.SingletonPlugin,
 
     def _replace_resource_download_urls(self, resources, package_name):
         for resource in resources:
-            if resource['resource_type'] == 'file':
+            if resource['url_type'] == 'upload':
                 resource['url'] = '%s/dataset/%s/download/%s' % (
                     tk.config.get('ckan.site_url', ''),
                     package_name, resource['name'])


### PR DESCRIPTION
Resources uploaded via the web gui don't get `resource_type` set, for some reason, so the new download url was not added for them. Using `url_type` should work for both harvested and uploaded resources.