### PR TITLE
disallow malicious bots from crawling

### DIFF
--- a/ckanext/stadtzhtheme/templates/robots.txt
+++ b/ckanext/stadtzhtheme/templates/robots.txt
@@ -1,0 +1,14 @@
+{% ckan_extends %}
+
+{% block additional_user_agents -%}
+User-agent: MJ12bot
+User-agent: SemrushBot
+User-agent: Yandex
+User-agent: YandexBot
+User-agent: UptimeRobot
+User-agent: AhrefsBot
+User-agent: BingBot
+User-agent: PetalBot
+Disallow: /
+
+{%- endblock %}


### PR DESCRIPTION
this is added as a particular group of bots is overloading the website with requests causing it to crash