### PR TITLE
the route name in tab header changed in the package 'read_base' templ…

### DIFF
--- a/ckanext/stadtzhtheme/templates/package/read_base.html
+++ b/ckanext/stadtzhtheme/templates/package/read_base.html
@@ -7,7 +7,7 @@
 {% block content_primary_nav %}
   {{ h.build_nav_icon('dataset_read', _('Dataset'), id=pkg.name) }}
   {{ h.build_nav_icon('dataset_groups', _('Groups'), id=pkg.name) }}
-  {{ h.build_nav_icon('dataset_showcase_list', _('Showcases'), id=pkg.name) }}
+  {{ h.build_nav_icon(showcase_dataset_showcase_list_route, _('Showcases'), id=pkg.name) }}
 {% endblock %}
 
 {# Get rid of info block (package title, follower count and follow button) #}


### PR DESCRIPTION
…ate in ckanext-showcases

therefore the template that overwrites this template is adapted to that change