### PR TITLE
Change `completelyIrregular` to `irregular`

### DIFF
--- a/ckanext/stadtzhtheme/dcat/profiles.py
+++ b/ckanext/stadtzhtheme/dcat/profiles.py
@@ -84,10 +84,10 @@ mapping_accrualPeriodicity = {
     'taeglich': 'http://purl.org/cld/freq/daily',
     'woechentlich': 'http://purl.org/cld/freq/weekly',
     'vierzehntäglich': 'http://purl.org/cld/freq/bimonthly',
-    'keines': 'http://purl.org/cld/freq/completelyIrregular',
-    'alle 4 Jahre': 'http://purl.org/cld/freq/completelyIrregular',
+    'keines': 'http://purl.org/cld/freq/irregular',
+    'alle 4 Jahre': 'http://purl.org/cld/freq/irregular',
     'sporadisch oder unregelmaessig':
-        'http://purl.org/cld/freq/completelyIrregular',
+        'http://purl.org/cld/freq/irregular',
 }
 
 ckan_locale_default = pylons.config.get('ckan.locale_default', 'de')


### PR DESCRIPTION
To fix the following error from the metadata check mail:

```
Dataset: 3D-Dachmodell LoD2 
A Validation Error occured at: Nf89d724ed19841ecacd5abec201a850e: Property: 'dct:accrualPeriodicity.' The frequency is expected from a controlled vocabulary http://purl.org/cld/freq. The given value could not be found in that vocabulary. Value received: 'http://purl.org/cld/freq/completelyIrregular' 
```