### PR TITLE
fix: Use frontend url for dataset landing pages

### DIFF
--- a/ckanext/stadtzhtheme/dcat/profiles.py
+++ b/ckanext/stadtzhtheme/dcat/profiles.py
@@ -159,7 +159,8 @@ class StadtzhSwissDcatProfile(RDFProfile, StadtzhProfile):
             self._add_triples_from_dict(dataset_dict, dataset_ref, basic_items)
 
             # landingPage is the original portal page
-            site_url = pylons.config.get('ckan.site_url', '')
+            site_url = pylons.config.get(
+                'ckanext.stadtzh-theme.frontend_url', '')
             g.add((
                 dataset_ref,
                 DCAT.landingPage,


### PR DESCRIPTION
Previously we used the CKAN site url, but this resulted in datasets that were harvested from OGDZH to opendata.swiss having landing pages on the CKAN backend.