### PR TITLE
fix: Fix adding assets

### DIFF
--- a/ckanext/stadtzhtheme/assets/stadtzhtheme.css
+++ b/ckanext/stadtzhtheme/assets/stadtzhtheme.css
@@ -351,3 +351,7 @@ ul.resource-list,
 .select2-search-choice-close, .select2-container-multi .select2-search-choice-close {
     top: 3px;
 }
+
+.dataset-resources {
+    padding-left: 0;
+}

--- a/ckanext/stadtzhtheme/assets/stadtzhtheme.css
+++ b/ckanext/stadtzhtheme/assets/stadtzhtheme.css
@@ -287,31 +287,17 @@ ul.resource-list,
     float:right
 }
 
-.format-label {
-    background: url(/icons.png) no-repeat 0 0;
+.format-label[data-format=kmz], .format-label[data-format*=kmz],
+.format-label[data-format=gpkg], .format-label[data-format*=gpkg],
+.format-label[data-format=ods], .format-label[data-format*=ods] {
     width: 32px;
     height: 35px;
-    background-position: 0px -62px;
+    background: url(/icons.png) no-repeat 0 -62px;
+    transform: none;
+    margin: auto;
 }
-
-.format-label[data-format=wms], .format-label[data-format*=wms] {
-    background-position: -352px -62px;
-}
-
-.format-label[data-format=wfs], .format-label[data-format*=wfs] {
-    background-position: -384px -62px;
-}
-
 .format-label[data-format=kmz], .format-label[data-format*=kmz] {
     background-position: -416px -62px;
-}
-
-.format-label[data-format=kml], .format-label[data-format*=kml] {
-    background-position: -448px -62px;
-}
-
-.format-label[data-format=wmts], .format-label[data-format*=wmts] {
-    background-position: -480px -62px;
 }
 
 .format-label[data-format=gpkg], .format-label[data-format*=gpkg] {
@@ -322,29 +308,8 @@ ul.resource-list,
     background-position: -544px -62px;
 }
 
-.format-label[data-format=odt], .format-label[data-format*=odt] {
-    background-position: -576px -62px;
-}
-
-.label[data-format=xml], .label[data-format*=xml] {
-    background-color: #aad450;
-}
-
-.label[data-format=wms], .label[data-format*=wms] {
-    background-color: #e4c80a;
-}
-
-.label[data-format=wfs], .label[data-format*=wfs] {
-    background-color: #df7661;
-}
-
-.label[data-format=kmz], .label[data-format*=kmz],
-.label[data-format=kml], .label[data-format*=kml] {
+.label[data-format=kmz], .label[data-format*=kmz] {
     background-color: #4472de;
-}
-
-.label[data-format=wmts], .label[data-format*=wmts] {
-    background-color: #75b285;
 }
 
 .label[data-format=gpkg], .label[data-format*=gpkg] {
@@ -353,10 +318,6 @@ ul.resource-list,
 
 .label[data-format=ods], .label[data-format*=ods] {
     background-color: #1c7143;
-}
-
-.label[data-format=odt], .label[data-format*=odt] {
-    background-color: #325598;
 }
 
 /* Large desktop */

--- a/ckanext/stadtzhtheme/plugin.py
+++ b/ckanext/stadtzhtheme/plugin.py
@@ -272,8 +272,7 @@ class StadtzhThemePlugin(plugins.SingletonPlugin,
 
         tk.add_template_directory(config, 'templates')
         tk.add_public_directory(config, 'public')
-        tk.add_resource('assets', 'stadtzh_theme_css')
-        tk.add_resource('assets', 'stadtzh_theme_js')
+        tk.add_resource('assets', 'stadtzh_theme')
 
         config['ckan.site_logo'] = '/logo.png'
 


### PR DESCRIPTION
We need to add the directory 'assets' as a resource under the name 'stadtzh_theme'. Then, in base.html, we can import the css as 'stadtzh_theme/stadtzh_theme_css' and the js as 'stadtzh_theme/stadtzh_theme_js'.