### PR TITLE
feat: add markdown-snippet field to resource

### DIFF
--- a/ckanext/stadtzhtheme/plugin.py
+++ b/ckanext/stadtzhtheme/plugin.py
@@ -449,6 +449,10 @@ class StadtzhThemePlugin(
             }
         )
 
+        schema["resources"].update(
+            {"markdown_snippet": [tk.get_validator("ignore_missing")]}
+        )
+
         return schema
 
     def create_package_schema(self):

--- a/ckanext/stadtzhtheme/templates/package/resource_read.html
+++ b/ckanext/stadtzhtheme/templates/package/resource_read.html
@@ -10,6 +10,11 @@
     {% endif %}
   {% endblock %}
   <div class="prose notes" property="rdfs:label">
+    {% if res.markdown_snippet %}
+    <div class="snippet">
+      {{ h.render_markdown(res.markdown_snippet) }}
+    </div>
+    {% endif %}
 
     {% set descriptions = h.get_resource_descriptions(res) %}
     {% if descriptions %}

--- a/ckanext/stadtzhtheme/templates/package/snippets/resource_form.html
+++ b/ckanext/stadtzhtheme/templates/package/snippets/resource_form.html
@@ -35,4 +35,9 @@
   {% block basic_fields_filename %}
     <input name="filename" value="{{ data.filename }}" type="hidden"/>
   {% endblock %}
+
+  {% block markdown_snippet %}
+    {{ form.markdown('markdown_snippet', id='field-description', label=_('Markdown zur Anzeige von interaktiven Notebooks'), placeholder=_('[![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](YOUR_NOTEBOOK_URL_HERE)'), value=data.markdown_snippet, error=errors.markdown_snippet) }}
+  {% endblock %}
+
 {% endblock %}


### PR DESCRIPTION
This field is intended to be displayed on the dataset-page where resources are listed. That way we can embed Links to Notebooks like colab or starter